### PR TITLE
Migrate to Artifact Registry & Update actions versions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -44,52 +44,51 @@ env:
   DOMAIN_NAME:  ${{ inputs.name }}.demo.community.intersystems.com
 
 # Leave this section untouched
-  PROJECT_ID:   iris-community-demos
-  CLUSTER_NAME: demo
-  GITHUB_SHA:   ${{ github.sha }}
-  GCR_LOCATION: eu.gcr.io
-  REGION:       europe-west2
-  NAMESPACE:    demo
-  SERVICE_PORT: ${{ inputs.port }}
+  PROJECT_ID:     iris-community-demos
+  CLUSTER_NAME:   demo
+  GITHUB_SHA:     ${{ github.sha }}
+  GITHUB_REPO:    ${{ github.repository }}
+  REGION:         europe-west2
+  NAMESPACE:      demo
+  SERVICE_PORT:   ${{ inputs.port }}
   SERVICE_MEMORY: ${{ inputs.memory }}
 
 jobs:
   deploy-cloud-run:
     # if: github.event.repository.fork == false && github.event.repository.is_template == false
     name: Deploy to Cloud Run
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ inputs.repository }}
         ref: ${{ inputs.ref }}
 
     - name: Google Authentication
-      uses: google-github-actions/auth@v1.0.0
+      uses: google-github-actions/auth@v2.1.7
       with:
         credentials_json: ${{ secrets.SERVICE_ACCOUNT_KEY }}
 
     - name: Get GKE credentials
-      uses: google-github-actions/get-gke-credentials@v1.0.1
+      uses: google-github-actions/get-gke-credentials@v2.3.0
       with:
         project_id:   ${{ env.PROJECT_ID }}
         cluster_name: ${{ env.CLUSTER_NAME }}
         location:     ${{ env.REGION }}
 
     - name: Setup gcloud cli
-      uses: google-github-actions/setup-gcloud@v1.0.0
+      uses: google-github-actions/setup-gcloud@v2.1.2
       with:
-        version: '412.0.0'
+        version: '504.0.0'
 
     - name: Authorize Docker push
       run: |
-        gcloud auth list
-        gcloud --quiet auth configure-docker
+        gcloud --quiet auth configure-docker ${REGION}-docker.pkg.dev
 
     - name: Build and Push image
       run: |
-        docker buildx build -t ${GCR_LOCATION}/${PROJECT_ID}/${IMAGE_NAME}:${GITHUB_SHA} --push .
+        docker buildx build -t ${REGION}-docker.pkg.dev/${PROJECT_ID}/community/${IMAGE_NAME}:${GITHUB_SHA} --push .
 
     - name: Deploy to Cloud Run
       run: |
@@ -97,17 +96,18 @@ jobs:
         gcloud config set project ${PROJECT_ID}
 
         echo "[INFO] Deploy service..."
-        gcloud run deploy ${SERVICE}         \
-          --platform gke                     \
-          --cluster ${CLUSTER_NAME}          \
-          --cluster-location ${REGION}       \
-          --namespace ${NAMESPACE}           \
-          --port ${SERVICE_PORT:-52773}      \
-          --min-instances 1                  \
-          --memory ${SERVICE_MEMORY:-512Mi}  \
-          --timeout 300                      \
-          --verbosity debug                  \
-          --image ${GCR_LOCATION}/${PROJECT_ID}/${IMAGE_NAME}:${GITHUB_SHA}
+        gcloud run deploy ${SERVICE}                \
+          --platform gke                            \
+          --cluster ${CLUSTER_NAME}                 \
+          --cluster-location ${REGION}              \
+          --namespace ${NAMESPACE}                  \
+          --port ${SERVICE_PORT:-52773}             \
+          --min-instances 1                         \
+          --memory ${SERVICE_MEMORY:-512Mi}         \
+          --timeout 300                             \
+          --verbosity debug                         \
+          --set-env-vars GITHUB_REPO=${GITHUB_REPO} \
+          --image ${REGION}-docker.pkg.dev/${PROJECT_ID}/community/${IMAGE_NAME}:${GITHUB_SHA}
 
         echo "[INFO] Create domain mappings..."
         if [[ $(gcloud run domain-mappings list --platform gke --cluster ${CLUSTER_NAME} --cluster-location ${REGION} --namespace ${NAMESPACE} --filter "DOMAIN=${DOMAIN_NAME}" | grep -v DOMAIN | wc -l) == 0 ]]; then


### PR DESCRIPTION
After 18 March 2025, Container Registry will be shut down. Here we migrate to Artifact Registry. Some github actions version are updated along the way.